### PR TITLE
run CI with least privileges

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,9 @@ env:
   GOLANGCI_VERSION: 'v1.52.2'
   STATICCHECK_VERSION: '2023.1.3'
 
+permissions:
+  contents: read
+
 jobs:
   vet:
     name: "vet"


### PR DESCRIPTION
By default, Github Actions are run with a significant amount of permissions, see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token for details. These are not necessary to lint and build the code.