### PR TITLE
docs: add available source and sink adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ source:
 Configures the Source Adapter, for the adapter configuration, check the
 documentation [here](./docs/adapters.md).
 
+### Available Source Adapters
+
+- Google
+- Outlook
+- [ZEP](https://www.zep.de/en/)
+
 ## Sink
 
 Example:
@@ -99,6 +105,11 @@ sink:
 
 Configures the Sink Adapter, for the adapter configuration, check the
 documentation [here](./docs/adapters.md).
+
+### Available Sink Adapters
+
+- Google
+- Outlook
 
 ## Transformers
 


### PR DESCRIPTION
while going through the readme one last time before open sourcing, i noticed that i removed the overview of available adapters. This PR reintroduces them.