### PR TITLE
Prefix metadata in ExtendedProperties of GCal events

### DIFF
--- a/internal/adapter/google/client.go
+++ b/internal/adapter/google/client.go
@@ -85,7 +85,7 @@ func (g *GCalClient) ListEvents(ctx context.Context, starttime time.Time, endtim
 
 func (g *GCalClient) CreateEvent(ctx context.Context, event models.Event) error {
 	extProperties := &calendar.EventExtendedProperties{
-		Private: event.Metadata.Map(),
+		Private: eventMetadataToEventProperties(event.Metadata),
 	}
 
 	var calendarAttendees []*calendar.EventAttendee
@@ -138,7 +138,7 @@ func isNotFound(err error) bool {
 
 func (g *GCalClient) UpdateEvent(ctx context.Context, event models.Event) error {
 	extProperties := &calendar.EventExtendedProperties{
-		Private: event.Metadata.Map(),
+		Private: eventMetadataToEventProperties(event.Metadata),
 	}
 
 	var calendarAttendees []*calendar.EventAttendee

--- a/internal/models/metadata.go
+++ b/internal/models/metadata.go
@@ -1,14 +1,8 @@
 package models
 
 import (
-	"errors"
 	"fmt"
 	"hash/fnv"
-)
-
-// Errors raised by package models
-var (
-	ErrMetadataNotFound = errors.New("could not find metadata")
 )
 
 // Metadata describes the metadata which is added to events read from the source.

--- a/internal/models/metadata.go
+++ b/internal/models/metadata.go
@@ -4,13 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"strings"
-)
-
-const (
-	keyEventID          = "EventID"
-	keyOriginalEventUri = "OriginalEventUri"
-	keySourceID         = "SourceID"
 )
 
 // Errors raised by package models
@@ -47,38 +40,5 @@ func NewEventMetadata(syncId, originalEventUri, sourceID string) *Metadata {
 		SyncID:           NewEventID(syncId),
 		OriginalEventUri: originalEventUri,
 		SourceID:         sourceID,
-	}
-}
-
-// EventMetadataFromMap creates the Metadata object from a map of strings
-// this func validates if the map contains the expected keys. If the keys are not the way we expect,
-// we're returing an error of type ErrMetadataNotFound
-func EventMetadataFromMap(md map[string]string) (*Metadata, error) {
-	var metadata Metadata
-
-	var ok bool
-	if metadata.SyncID, ok = md[keyEventID]; !ok {
-		return nil, fmt.Errorf("%w: key not exists %s", ErrMetadataNotFound, keyEventID)
-	}
-
-	if metadata.OriginalEventUri, ok = md[keyOriginalEventUri]; !ok {
-		return nil, fmt.Errorf("%w: key not exists %s", ErrMetadataNotFound, keyOriginalEventUri)
-	}
-
-	if metadata.SourceID, ok = md[keySourceID]; !ok {
-		return nil, fmt.Errorf("%w: key not exists %s", ErrMetadataNotFound, keySourceID)
-	}
-	metadata.SourceID = strings.Trim(metadata.SourceID, "\"\\")
-
-	return &metadata, nil
-}
-
-// Map returns a map[string]string of the metadata.
-// The keys match the Metadata struct field names.
-func (m Metadata) Map() map[string]string {
-	return map[string]string{
-		keyEventID:          m.SyncID,
-		keyOriginalEventUri: m.OriginalEventUri,
-		keySourceID:         m.SourceID,
 	}
 }

--- a/internal/models/metadata.go
+++ b/internal/models/metadata.go
@@ -29,9 +29,9 @@ func Hash(s string) uint64 {
 }
 
 func NewEventID(seed string) string {
-  // We hash the event id, as we need some common denominator for the event IDs
-  // We can't use the original event id as the event id in the sink, because the allowed formats differ
-  // between the adapters.
+	// We hash the event id, as we need some common denominator for the event IDs
+	// We can't use the original event id as the event id in the sink, because the allowed formats differ
+	// between the adapters.
 	return fmt.Sprint(Hash(seed))
 }
 

--- a/internal/sync/controller.go
+++ b/internal/sync/controller.go
@@ -201,11 +201,7 @@ func (p Controller) diffEvents(sourceEvents []models.Event, sinkEvents []models.
 
 		switch {
 		case exists:
-		case event.Metadata.SourceID == "":
-			// An event which has not been synced correctly or has been synced prior to the SourceID implementation
-			// should rather be removed. If the event still exists in the sourceEvents, it will eventually be re-synced.
-			p.logger.Info("event metadata corrupted (SourceID empty), deleting", logFields(event)...)
-			deleteEvents = append(deleteEvents, event)
+			// Nothing to do
 
 		case event.Metadata.SourceID == p.source.GetSourceID():
 			p.logger.Info("sinkEvent is not (anymore) in sourceEvents, marked for removal", logFields(event)...)


### PR DESCRIPTION
This PR removes the (not really necessary) special case to clean up events with an emtpy (but existing) SourceID field in their ExtendedProperties, as suggested in #33.

The more important change is the introduction of a prefix for the metadata fields to prevent potential collisions. To ensure backwards compatibility, the code falls back to the old unprefixed keys if the prefixed keys do not exist. The idea here is to eventually drop support for the unprefixed keys, but support both to simplify the transition.