### PR TITLE
Fixed outlook description mapping

### DIFF
--- a/internal/adapter/outlook_http/client.go
+++ b/internal/adapter/outlook_http/client.go
@@ -272,7 +272,7 @@ func (o OutlookClient) outlookEventToEvent(oe Event, adapterSourceID string) (e 
 		ICalUID:     oe.UID,
 		ID:          oe.ID,
 		Title:       oe.Subject,
-		Description: e.Description,
+		Description: oe.Body.Content,
 		Location:    oe.Location.Name,
 		StartTime:   startTime,
 		EndTime:     endTime,


### PR DESCRIPTION
Fix for the description mapping of the outlook adapter. Might need a deeper inspection concerning the content type und the general Content. 