### PR TITLE
feat: Implement option to enable / disable sync of declined events

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on: [ push ]
 env:
   GO_VERSION: '1.21.0'
   GO_VERSION_SHORT: '1.21'
-  GOLANGCI_VERSION: 'v1.52.2'
+  GOLANGCI_VERSION: 'v1.54.0'
   STATICCHECK_VERSION: '2023.1.3'
 
 permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,8 @@ name: Build
 on: [ push ]
 
 env:
-  GO_VERSION: '1.20.4'
-  GO_VERSION_SHORT: '1.20'
+  GO_VERSION: '1.21.0'
+  GO_VERSION_SHORT: '1.21'
   GOLANGCI_VERSION: 'v1.52.2'
   STATICCHECK_VERSION: '2023.1.3'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+env:
+  GO_VERSION: '1.21.0'
+
 permissions:
   contents: write
   packages: write
@@ -19,6 +22,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Log in to GitHub container registry
         uses: docker/login-action@v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+---
 before:
   hooks:
     - go mod tidy

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ sync:
   end: 
     identifier: MonthEnd # last day of the current month 
     offset: +1 # MonthEnd +1 month (end of next month)
-  sync_declined_events: false # If you want to sync events which you declined in the source calendar, set to true
 ```
 
 ## Source
@@ -135,6 +134,21 @@ transformations:
 
 The transformers are applied in a specific order. The order is defined here:
 [`internal/sync/transformer.go`](./internal/sync/transformer.go)
+
+## Filters
+
+In some cases events should not be synced. For example, declined events might
+create too much noise in the target calendar. These can be filtered by enabling
+the corresponding filter.
+
+```yaml
+# Filters remove events from being synced due to different criteria
+filters:
+  # Events where you declined the invitation aren't synced
+  - name: DeclinedEvents
+  # Events which cover the full day aren't synced
+  - name: AllDayEvents
+```
 
 # Cleaning Up
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ sync:
   end: 
     identifier: MonthEnd # last day of the current month 
     offset: +1 # MonthEnd +1 month (end of next month)
+  sync_declined_events: false # If you want to sync events which you declined in the source calendar, set to true
 ```
 
 ## Source

--- a/cmd/calendarsync/main.go
+++ b/cmd/calendarsync/main.go
@@ -164,7 +164,7 @@ func Run(c *cli.Context) error {
 		}
 	}
 
-	controller := sync.NewController(log.Default(), sourceAdapter, sinkAdapter, cfg.Sync.SyncDeclinedEvents, sync.TransformerFactory(cfg.Transformations)...)
+	controller := sync.NewController(log.Default(), sourceAdapter, sinkAdapter, sync.TransformerFactory(cfg.Transformations), sync.FilterFactory(cfg.Filters))
 	if cfg.UpdateConcurrency != 0 {
 		controller.SetConcurrency(cfg.UpdateConcurrency)
 	}

--- a/cmd/calendarsync/main.go
+++ b/cmd/calendarsync/main.go
@@ -164,7 +164,7 @@ func Run(c *cli.Context) error {
 		}
 	}
 
-	controller := sync.NewController(log.Default(), sourceAdapter, sinkAdapter, sync.TransformerFactory(cfg.Transformations)...)
+	controller := sync.NewController(log.Default(), sourceAdapter, sinkAdapter, cfg.Sync.SyncDeclinedEvents, sync.TransformerFactory(cfg.Transformations)...)
 	if cfg.UpdateConcurrency != 0 {
 		controller.SetConcurrency(cfg.UpdateConcurrency)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: '3.4'
 
 services:

--- a/example.sync.yaml
+++ b/example.sync.yaml
@@ -55,6 +55,13 @@ transformations:
     config:
       UseEmailAsDisplayName: true
 
+# Filters remove events from being synced due to different criteria
+filters:
+  # Events where you declined the invitation aren't synced
+  - name: DeclinedEvents
+  # Events which cover the full day aren't synced
+  - name: AllDayEvents
+
 # Perform multiple calendar updates concurrently
 # Defaults to 1 if not set
 updateConcurrency: 3

--- a/example.sync.yaml
+++ b/example.sync.yaml
@@ -6,6 +6,7 @@ sync:
   end:
     identifier: MonthEnd # last day of the current month
     offset: +1 # MonthEnd +1 month (end of next month)
+  sync_declined_events: false
 
 auth:
   storage_mode: yaml

--- a/example.sync.yaml
+++ b/example.sync.yaml
@@ -6,7 +6,6 @@ sync:
   end:
     identifier: MonthEnd # last day of the current month
     offset: +1 # MonthEnd +1 month (end of next month)
-  sync_declined_events: false
 
 auth:
   storage_mode: yaml

--- a/internal/adapter/google/event.go
+++ b/internal/adapter/google/event.go
@@ -15,7 +15,11 @@ func calendarEventToEvent(e *calendar.Event, adapterSourceID string) models.Even
 	metadata := ensureMetadata(e, adapterSourceID)
 
 	var attendees []models.Attendee
+	var hasEventAccepted bool = true
 	for _, eventAttendee := range e.Attendees {
+		if eventAttendee.Self && eventAttendee.ResponseStatus == "declined" {
+			hasEventAccepted = false
+		}
 		attendees = append(attendees, models.Attendee{
 			Email:       eventAttendee.Email,
 			DisplayName: eventAttendee.DisplayName,
@@ -47,6 +51,7 @@ func calendarEventToEvent(e *calendar.Event, adapterSourceID string) models.Even
 		Attendees:   attendees,
 		Reminders:   reminders,
 		MeetingLink: e.HangoutLink,
+		Accepted:    hasEventAccepted,
 	}
 }
 

--- a/internal/adapter/outlook_http/client.go
+++ b/internal/adapter/outlook_http/client.go
@@ -267,6 +267,10 @@ func (o OutlookClient) outlookEventToEvent(oe Event, adapterSourceID string) (e 
 			},
 		})
 	}
+	var hasEventAccepted bool = true
+	if oe.ResponseStatus.Response == "declined" {
+		hasEventAccepted = false
+	}
 
 	bufEvent = models.Event{
 		ICalUID:     oe.UID,
@@ -280,6 +284,7 @@ func (o OutlookClient) outlookEventToEvent(oe Event, adapterSourceID string) (e 
 		Attendees:   attendees,
 		Reminders:   reminders,
 		MeetingLink: oe.OnlineMeetingUrl,
+		Accepted:    hasEventAccepted,
 	}
 
 	if oe.IsAllDay {

--- a/internal/adapter/outlook_http/models.go
+++ b/internal/adapter/outlook_http/models.go
@@ -12,21 +12,22 @@ type EventList struct {
 }
 
 type Event struct {
-	ID                         string       `json:"id"`
-	UID                        string       `json:"iCalUId"`
-	ChangeKey                  string       `json:"changeKey"`
-	HtmlLink                   string       `json:"webLink"`
-	Subject                    string       `json:"subject"`
-	Start                      Time         `json:"start"`
-	End                        Time         `json:"end"`
-	Body                       Body         `json:"body,omitempty"`
-	Attendees                  []Attendee   `json:"attendees,omitempty"`
-	Location                   Location     `json:"location"`
-	IsReminderOn               bool         `json:"isReminderOn"`
-	ReminderMinutesBeforeStart int          `json:"reminderMinutesBeforeStart"`
-	Extensions                 []Extensions `json:"extensions"`
-	IsAllDay                   bool         `json:"isAllDay"`
-	OnlineMeetingUrl           string       `json:"onlineMeetingUrl"`
+	ID                         string         `json:"id"`
+	UID                        string         `json:"iCalUId"`
+	ChangeKey                  string         `json:"changeKey"`
+	HtmlLink                   string         `json:"webLink"`
+	Subject                    string         `json:"subject"`
+	Start                      Time           `json:"start"`
+	End                        Time           `json:"end"`
+	Body                       Body           `json:"body,omitempty"`
+	Attendees                  []Attendee     `json:"attendees,omitempty"`
+	Location                   Location       `json:"location"`
+	IsReminderOn               bool           `json:"isReminderOn"`
+	ReminderMinutesBeforeStart int            `json:"reminderMinutesBeforeStart"`
+	Extensions                 []Extensions   `json:"extensions"`
+	IsAllDay                   bool           `json:"isAllDay"`
+	OnlineMeetingUrl           string         `json:"onlineMeetingUrl"`
+	ResponseStatus             ResponseStatus `json:"responseStatus,omitempty"`
 }
 
 type Extensions struct {
@@ -34,6 +35,12 @@ type Extensions struct {
 	ExtensionName string `json:"extensionName"`
 	// needs to be embedded, Microsoft returns a 500 on an non-embedded object
 	models.Metadata
+}
+
+type ResponseStatus struct {
+	Response string `json:"response,omitempty"`
+	// there's an additional field called `time` which returns date and time when the response was returned
+	// but we don't need that
 }
 
 type Body struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,11 +8,11 @@ import (
 )
 
 type File struct {
-	Path   string
-	Auth   AuthStorage
-	Source Source `yaml:"source"`
-	Sink   Sink   `yaml:"sink"`
-	// TODO: filters for source events
+	Path              string
+	Auth              AuthStorage
+	Source            Source        `yaml:"source"`
+	Sink              Sink          `yaml:"sink"`
+	Filters           []Filter      `yaml:"filters,omitempty"`
 	Transformations   []Transformer `yaml:"transformations,omitempty"`
 	Sync              Sync          `yaml:"sync"`
 	UpdateConcurrency int           `yaml:"updateConcurrency,omitempty"`
@@ -77,11 +77,17 @@ type Transformer struct {
 	Config CustomMap `yaml:"config"`
 }
 
+type Filter struct {
+	// Name of the filter
+	Name string `yaml:"name"`
+	// Any kind of parameter which can be passed to a filter.
+	Config CustomMap `yaml:"config"`
+}
+
 // Sync configuration
 type Sync struct {
-	StartTime          SyncTime `yaml:"start"`
-	EndTime            SyncTime `yaml:"end"`
-	SyncDeclinedEvents bool     `yaml:"sync_declined_events"`
+	StartTime SyncTime `yaml:"start"`
+	EndTime   SyncTime `yaml:"end"`
 }
 
 type SyncTime struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,8 +79,9 @@ type Transformer struct {
 
 // Sync configuration
 type Sync struct {
-	StartTime SyncTime `yaml:"start"`
-	EndTime   SyncTime `yaml:"end"`
+	StartTime          SyncTime `yaml:"start"`
+	EndTime            SyncTime `yaml:"end"`
+	SyncDeclinedEvents bool     `yaml:"sync_declined_events"`
 }
 
 type SyncTime struct {

--- a/internal/filter/allDayEvents.go
+++ b/internal/filter/allDayEvents.go
@@ -1,0 +1,25 @@
+package filter
+
+import (
+	"fmt"
+
+	"github.com/inovex/CalendarSync/internal/models"
+)
+
+type AllDayEvents struct {
+}
+
+func (a AllDayEvents) Name() string {
+	return "AllDayEvents"
+}
+
+func (a AllDayEvents) Filter(events []models.Event) (filteredEvents []models.Event) {
+	for _, event := range events {
+		if !event.AllDay {
+			filteredEvents = append(filteredEvents, event)
+		} else {
+			fmt.Println("Filtered!")
+		}
+	}
+	return filteredEvents
+}

--- a/internal/filter/allDayEvents.go
+++ b/internal/filter/allDayEvents.go
@@ -1,8 +1,6 @@
 package filter
 
 import (
-	"fmt"
-
 	"github.com/inovex/CalendarSync/internal/models"
 )
 
@@ -13,13 +11,6 @@ func (a AllDayEvents) Name() string {
 	return "AllDayEvents"
 }
 
-func (a AllDayEvents) Filter(events []models.Event) (filteredEvents []models.Event) {
-	for _, event := range events {
-		if !event.AllDay {
-			filteredEvents = append(filteredEvents, event)
-		} else {
-			fmt.Println("Filtered!")
-		}
-	}
-	return filteredEvents
+func (a AllDayEvents) Filter(event models.Event) bool {
+	return !event.AllDay
 }

--- a/internal/filter/declinedEvents.go
+++ b/internal/filter/declinedEvents.go
@@ -1,0 +1,20 @@
+package filter
+
+import (
+	"github.com/inovex/CalendarSync/internal/models"
+)
+
+type DeclinedEvents struct{}
+
+func (d DeclinedEvents) Name() string {
+	return "DeclinedEvents"
+}
+
+func (d DeclinedEvents) Filter(events []models.Event) (filteredEvents []models.Event) {
+	for _, event := range events {
+		if event.Accepted {
+			filteredEvents = append(filteredEvents, event)
+		}
+	}
+	return filteredEvents
+}

--- a/internal/filter/declinedEvents.go
+++ b/internal/filter/declinedEvents.go
@@ -10,11 +10,6 @@ func (d DeclinedEvents) Name() string {
 	return "DeclinedEvents"
 }
 
-func (d DeclinedEvents) Filter(events []models.Event) (filteredEvents []models.Event) {
-	for _, event := range events {
-		if event.Accepted {
-			filteredEvents = append(filteredEvents, event)
-		}
-	}
-	return filteredEvents
+func (d DeclinedEvents) Filter(event models.Event) bool {
+	return event.Accepted
 }

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -27,6 +27,7 @@ type Event struct {
 	Attendees   Attendees
 	Reminders   Reminders
 	MeetingLink string
+	Accepted    bool
 }
 
 type Reminders []Reminder

--- a/internal/sync/controller.go
+++ b/internal/sync/controller.go
@@ -20,20 +20,22 @@ var (
 type Controller struct {
 	source Source
 	// transformers are applied in order
-	transformers []Transformer
-	sink         Sink
-	concurrency  int
-	logger       *log.Logger
+	transformers       []Transformer
+	sink               Sink
+	concurrency        int
+	logger             *log.Logger
+	SyncDeclinedEvents bool
 }
 
 // NewController constructs a new Controller.
-func NewController(logger *log.Logger, source Source, sink Sink, transformer ...Transformer) Controller {
+func NewController(logger *log.Logger, source Source, sink Sink, SyncDeclinedEvents bool, transformer ...Transformer) Controller {
 	return Controller{
-		concurrency:  1,
-		source:       source,
-		transformers: transformer,
-		sink:         sink,
-		logger:       logger,
+		concurrency:        1,
+		source:             source,
+		transformers:       transformer,
+		sink:               sink,
+		logger:             logger,
+		SyncDeclinedEvents: SyncDeclinedEvents,
 	}
 }
 

--- a/internal/sync/controller.go
+++ b/internal/sync/controller.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/inovex/CalendarSync/internal/models"
@@ -84,7 +83,13 @@ func (p Controller) SynchroniseTimeframe(ctx context.Context, start time.Time, e
 		p.logger.Info("loaded filter", "name", filter.Name())
 	}
 
-	filteredEventsInSource = FilterEvents(eventsInSource, p.filters...)
+	for _, event := range eventsInSource {
+		if FilterEvent(event, p.filters...) {
+			filteredEventsInSource = append(filteredEventsInSource, event)
+		} else {
+			p.logger.Debug("filter rejects event", logFields(event)...)
+		}
+	}
 
 	// Transform source events before comparing them to the sink events
 	transformedEventsInSource := []models.Event{}

--- a/internal/sync/controller.go
+++ b/internal/sync/controller.go
@@ -29,14 +29,14 @@ type Controller struct {
 }
 
 // NewController constructs a new Controller.
-func NewController(logger *log.Logger, source Source, sink Sink, SyncDeclinedEvents bool, transformer ...Transformer) Controller {
+func NewController(logger *log.Logger, source Source, sink Sink, transformer []Transformer, filters []Filter) Controller {
 	return Controller{
-		concurrency:        1,
-		source:             source,
-		transformers:       transformer,
-		sink:               sink,
-		logger:             logger,
-		SyncDeclinedEvents: SyncDeclinedEvents,
+		concurrency:  1,
+		source:       source,
+		transformers: transformer,
+		filters:      filters,
+		sink:         sink,
+		logger:       logger,
 	}
 }
 

--- a/internal/sync/controller_test.go
+++ b/internal/sync/controller_test.go
@@ -34,7 +34,10 @@ func (suite *ControllerTestSuite) SetupTest() {
 		{Name: "KeepTitle"},
 		{Name: "KeepReminders"},
 	})
-	suite.controller = NewController(log.Default(), suite.source, suite.sink, false, transformers...)
+	filters := FilterFactory([]config.Filter{
+		{Name: "DeclinedEvents"},
+	})
+	suite.controller = NewController(log.Default(), suite.source, suite.sink, transformers, filters)
 }
 
 // TestDryRun tests that no acutal adapter func is called

--- a/internal/sync/controller_test.go
+++ b/internal/sync/controller_test.go
@@ -34,7 +34,7 @@ func (suite *ControllerTestSuite) SetupTest() {
 		{Name: "KeepTitle"},
 		{Name: "KeepReminders"},
 	})
-	suite.controller = NewController(log.Default(), suite.source, suite.sink, transformers...)
+	suite.controller = NewController(log.Default(), suite.source, suite.sink, false, transformers...)
 }
 
 // TestDryRun tests that no acutal adapter func is called
@@ -54,6 +54,7 @@ func (suite *ControllerTestSuite) TestDryRun() {
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed1", "uri", "sourceID"),
 			Reminders:   []models.Reminder{{Actions: models.ReminderActionDisplay, Trigger: models.ReminderTrigger{PointInTime: startTime.Add(-10 * time.Minute)}}},
+			Accepted:    true,
 		},
 		{
 			ICalUID:     "testID3",
@@ -65,6 +66,7 @@ func (suite *ControllerTestSuite) TestDryRun() {
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed3", "uri", "sourceID"),
 			Reminders:   []models.Reminder{{Actions: models.ReminderActionDisplay, Trigger: models.ReminderTrigger{PointInTime: startTime.Add(-10 * time.Minute)}}},
+			Accepted:    true,
 		},
 	}
 
@@ -197,6 +199,7 @@ func (suite *ControllerTestSuite) TestCreateEventsEmptySink() {
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed1", "uri", "sourceID"),
 			Reminders:   []models.Reminder{{Actions: models.ReminderActionDisplay, Trigger: models.ReminderTrigger{PointInTime: time.Now().Add(-10 * time.Minute)}}},
+			Accepted:    true,
 		},
 		{
 			ICalUID:     "testID2",
@@ -207,6 +210,7 @@ func (suite *ControllerTestSuite) TestCreateEventsEmptySink() {
 			EndTime:     time.Now().Add(time.Hour),
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed2", "uri", "sourceID"),
+			Accepted:    true,
 		},
 	}
 
@@ -241,6 +245,7 @@ func (suite *ControllerTestSuite) TestDeleteEventsNotInSink() {
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed1", "uri", "sourceID"),
 			Reminders:   []models.Reminder{{Actions: models.ReminderActionDisplay, Trigger: models.ReminderTrigger{PointInTime: startTime.Add(-10 * time.Minute)}}},
+			Accepted:    true,
 		},
 	}
 	sinkEvents := []models.Event{
@@ -325,6 +330,7 @@ func (suite *ControllerTestSuite) TestUpdateEventsPrefilledSink() {
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed1", "uri", "sourceID"),
 			Reminders:   []models.Reminder{{Actions: models.ReminderActionDisplay, Trigger: models.ReminderTrigger{PointInTime: time.Now().Add(-10 * time.Minute)}}},
+			Accepted:    true,
 		},
 		{
 			ICalUID:     "testID2",
@@ -335,6 +341,7 @@ func (suite *ControllerTestSuite) TestUpdateEventsPrefilledSink() {
 			EndTime:     endTime,
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed2", "uri", "sourceID"),
+			Accepted:    true,
 		},
 		{
 			ICalUID:     "testID3",
@@ -345,6 +352,7 @@ func (suite *ControllerTestSuite) TestUpdateEventsPrefilledSink() {
 			EndTime:     endTime,
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed3", "uri", "sourceID"),
+			Accepted:    true,
 		},
 		{
 			ICalUID:     "testID4",
@@ -356,6 +364,7 @@ func (suite *ControllerTestSuite) TestUpdateEventsPrefilledSink() {
 			AllDay:      false,
 			Metadata:    models.NewEventMetadata("seed4", "uri", "sourceID"),
 			Reminders:   []models.Reminder{{Actions: models.ReminderActionDisplay, Trigger: models.ReminderTrigger{PointInTime: time.Now().Add(-30 * time.Minute)}}},
+			Accepted:    true,
 		},
 	}
 
@@ -434,6 +443,51 @@ func (suite *ControllerTestSuite) TestUpdateEventsPrefilledSink() {
 	suite.sink.AssertCalled(suite.T(), "EventsInTimeframe", ctx, startTime, endTime)
 	suite.sink.AssertNumberOfCalls(suite.T(), "UpdateEvent", eventsToBeUpdated)
 	suite.sink.AssertNotCalled(suite.T(), "CreateEvent", ctx, mock.AnythingOfType("models.Event"))
+	suite.sink.AssertNotCalled(suite.T(), "DeleteEvent", ctx, mock.AnythingOfType("models.Event"))
+}
+
+// TestCreateEventsDeclined asserts that, only the accepted event gets synced
+func (suite *ControllerTestSuite) TestCreateEventsDeclined() {
+	ctx := context.Background()
+	startTime := time.Now()
+	endTime := startTime.Add(2 * time.Hour)
+	eventsToCreate := []models.Event{
+		{
+			ICalUID:     "testID",
+			ID:          "testUID",
+			Title:       "Title",
+			Description: "Description",
+			StartTime:   time.Now(),
+			EndTime:     time.Now().Add(time.Hour),
+			AllDay:      false,
+			Metadata:    models.NewEventMetadata("seed1", "uri", "sourceID"),
+			Reminders:   []models.Reminder{{Actions: models.ReminderActionDisplay, Trigger: models.ReminderTrigger{PointInTime: time.Now().Add(-10 * time.Minute)}}},
+			Accepted:    true,
+		},
+		{
+			ICalUID:     "testID2",
+			ID:          "testUID2",
+			Title:       "Title",
+			Description: "Description",
+			StartTime:   time.Now(),
+			EndTime:     time.Now().Add(time.Hour),
+			AllDay:      false,
+			Metadata:    models.NewEventMetadata("seed2", "uri", "sourceID"),
+			Accepted:    false,
+		},
+	}
+
+	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(eventsToCreate, nil)
+	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(nil, nil)
+	suite.sink.On("CreateEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
+
+	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, false)
+	assert.NoError(suite.T(), err)
+
+	suite.source.AssertCalled(suite.T(), "EventsInTimeframe", ctx, startTime, endTime)
+	suite.sink.AssertCalled(suite.T(), "EventsInTimeframe", ctx, startTime, endTime)
+	suite.sink.AssertNumberOfCalls(suite.T(), "CreateEvent", len(eventsToCreate)-1)
+	suite.sink.AssertNotCalled(suite.T(), "UpdateEvent", ctx, mock.AnythingOfType("models.Event"))
 	suite.sink.AssertNotCalled(suite.T(), "DeleteEvent", ctx, mock.AnythingOfType("models.Event"))
 }
 

--- a/internal/sync/filter.go
+++ b/internal/sync/filter.go
@@ -11,14 +11,20 @@ import (
 
 type Filter interface {
 	NamedComponent
-	Filter(events []models.Event) []models.Event
+	// Filter returns true to keep the event
+	Filter(event models.Event) bool
 }
 
-func FilterEvents(events []models.Event, filters ...Filter) (filteredEvents []models.Event) {
+// FilterEvent returns false if one of the filters rejects the event
+func FilterEvent(event models.Event, filters ...Filter) (result bool) {
 	for _, filter := range filters {
-		events = filter.Filter(events)
+		// If the filter returns false (or: filters the event), then return false
+		if !filter.Filter(event) {
+			return false
+		}
 	}
-	return events
+	// otherwise keep the event
+	return true
 }
 
 var (

--- a/internal/sync/filter.go
+++ b/internal/sync/filter.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/inovex/CalendarSync/internal/config"
@@ -57,45 +56,7 @@ func FilterFactory(configuredFilters []config.Filter) (loadedFilters []Filter) {
 	return sortedAndLoadedFilter
 }
 
-func autoConfigureFilter(filter Filter, config config.CustomMap) {
-	ps := reflect.ValueOf(filter)
-	s := ps.Elem()
-	if s.Kind() == reflect.Struct {
-		for key, value := range config {
-			field := s.FieldByName(key)
-			if field.IsValid() && field.CanSet() {
-				switch field.Kind() {
-				case reflect.Int,
-					reflect.Int8,
-					reflect.Int16,
-					reflect.Int32,
-					reflect.Int64:
-					field.SetInt(value.(int64))
-				case reflect.Bool:
-					field.SetBool(value.(bool))
-				case reflect.String:
-					field.SetString(value.(string))
-				default:
-					panic(fmt.Sprintf("autoConfigure(): unknown kind '%s' for field '%s'", key, field.Kind().String()))
-				}
-			}
-		}
-	}
-}
-
 func filterFromConfig(filter Filter, config config.CustomMap) Filter {
-	autoConfigureFilter(filter, config)
+	autoConfigure(filter, config)
 	return filter
-}
-
-func removeDuplicateInt(intSlice []int) []int {
-	allKeys := make(map[int]bool)
-	list := []int{}
-	for _, item := range intSlice {
-		if _, value := allKeys[item]; !value {
-			allKeys[item] = true
-			list = append(list, item)
-		}
-	}
-	return list
 }

--- a/internal/sync/filter.go
+++ b/internal/sync/filter.go
@@ -1,0 +1,101 @@
+package sync
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/inovex/CalendarSync/internal/config"
+	"github.com/inovex/CalendarSync/internal/filter"
+	"github.com/inovex/CalendarSync/internal/models"
+)
+
+type Filter interface {
+	NamedComponent
+	Filter(events []models.Event) []models.Event
+}
+
+func FilterEvents(events []models.Event, filters ...Filter) (filteredEvents []models.Event) {
+	for _, filter := range filters {
+		events = filter.Filter(events)
+	}
+	return events
+}
+
+var (
+	filterConfigMapping = map[string]Filter{
+		"DeclinedEvents": &filter.DeclinedEvents{},
+		"AllDayEvents":   &filter.AllDayEvents{},
+	}
+
+	filterOrder = []string{
+		"DeclinedEvents",
+		"AllDayEvents",
+	}
+)
+
+func FilterFactory(configuredFilters []config.Filter) (loadedFilters []Filter) {
+	for _, configuredFilter := range configuredFilters {
+		if _, nameExists := filterConfigMapping[configuredFilter.Name]; !nameExists {
+			// todo: handle properly
+			panic(fmt.Sprintf("unknown filter: %s", configuredFilter.Name))
+		}
+		// load the default Transformer for the configured name and initialize it based on the config
+		filterDefault := filterConfigMapping[configuredFilter.Name]
+		loadedFilters = append(loadedFilters, filterFromConfig(filterDefault, configuredFilter.Config))
+	}
+
+	var sortedAndLoadedFilter []Filter
+	for _, name := range filterOrder {
+		for _, v := range loadedFilters {
+			if strings.EqualFold(name, v.Name()) {
+				sortedAndLoadedFilter = append(sortedAndLoadedFilter, v)
+			}
+		}
+	}
+
+	return sortedAndLoadedFilter
+}
+
+func autoConfigureFilter(filter Filter, config config.CustomMap) {
+	ps := reflect.ValueOf(filter)
+	s := ps.Elem()
+	if s.Kind() == reflect.Struct {
+		for key, value := range config {
+			field := s.FieldByName(key)
+			if field.IsValid() && field.CanSet() {
+				switch field.Kind() {
+				case reflect.Int,
+					reflect.Int8,
+					reflect.Int16,
+					reflect.Int32,
+					reflect.Int64:
+					field.SetInt(value.(int64))
+				case reflect.Bool:
+					field.SetBool(value.(bool))
+				case reflect.String:
+					field.SetString(value.(string))
+				default:
+					panic(fmt.Sprintf("autoConfigure(): unknown kind '%s' for field '%s'", key, field.Kind().String()))
+				}
+			}
+		}
+	}
+}
+
+func filterFromConfig(filter Filter, config config.CustomMap) Filter {
+	autoConfigureFilter(filter, config)
+	return filter
+}
+
+func removeDuplicateInt(intSlice []int) []int {
+	allKeys := make(map[int]bool)
+	list := []int{}
+	for _, item := range intSlice {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}

--- a/internal/sync/transformer.go
+++ b/internal/sync/transformer.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/inovex/CalendarSync/internal/config"
@@ -77,34 +76,6 @@ func TransformerFactory(configuredTransformers []config.Transformer) (loadedTran
 	}
 
 	return sortedAndLoadedTransformer
-}
-
-// autoConfigure can automatically map keys of the config.CustomMap to fields of a given Transformer implementation.
-// TODO: I kinda wrote this in a hurry. Re-visit this.
-func autoConfigure(transformer Transformer, config config.CustomMap) {
-	ps := reflect.ValueOf(transformer)
-	s := ps.Elem()
-	if s.Kind() == reflect.Struct {
-		for key, value := range config {
-			field := s.FieldByName(key)
-			if field.IsValid() && field.CanSet() {
-				switch field.Kind() {
-				case reflect.Int,
-					reflect.Int8,
-					reflect.Int16,
-					reflect.Int32,
-					reflect.Int64:
-					field.SetInt(value.(int64))
-				case reflect.Bool:
-					field.SetBool(value.(bool))
-				case reflect.String:
-					field.SetString(value.(string))
-				default:
-					panic(fmt.Sprintf("autoConfigure(): unknown kind '%s' for field '%s'", key, field.Kind().String()))
-				}
-			}
-		}
-	}
 }
 
 func TransformerFromConfig(transformer Transformer, config config.CustomMap) Transformer {

--- a/internal/sync/util.go
+++ b/internal/sync/util.go
@@ -1,0 +1,34 @@
+package sync
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/inovex/CalendarSync/internal/config"
+)
+
+func autoConfigure(object any, config config.CustomMap) {
+	ps := reflect.ValueOf(object)
+	s := ps.Elem()
+	if s.Kind() == reflect.Struct {
+		for key, value := range config {
+			field := s.FieldByName(key)
+			if field.IsValid() && field.CanSet() {
+				switch field.Kind() {
+				case reflect.Int,
+					reflect.Int8,
+					reflect.Int16,
+					reflect.Int32,
+					reflect.Int64:
+					field.SetInt(value.(int64))
+				case reflect.Bool:
+					field.SetBool(value.(bool))
+				case reflect.String:
+					field.SetString(value.(string))
+				default:
+					panic(fmt.Sprintf("autoConfigure(): unknown kind '%s' for field '%s'", key, field.Kind().String()))
+				}
+			}
+		}
+	}
+}

--- a/testdata/testconfig.yaml
+++ b/testdata/testconfig.yaml
@@ -1,3 +1,4 @@
+---
 sync:
   start:
     identifier: MonthStart # 1st of the current month


### PR DESCRIPTION
- fmt: make the linter happy and add document starts to yamls
- feat: add Accepted field to models.Event
- feat(outlook): add ResponseStatus field and map to models.Event.Accepted
- feat(google): check for Event Response and map to models.Event.Accepted
- feat: add sync_declined_events field to config
- feat: add SyncDeclinedEvents field to controller struct
- test: modify tests for the newly introduced accepted field and controller property
- feat: add function to remove declined events if config parameter is set
- docs: add sync_declined_fields parameter to readme.md
