### PR TITLE
refactor: change the default configuration into a explicit structed

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type File struct {
@@ -18,29 +18,27 @@ type File struct {
 	UpdateConcurrency int           `yaml:"updateConcurrency,omitempty"`
 }
 
-func NewFromFile(file string) (cfg *File, err error) {
-	yamlFile, err := os.ReadFile(file)
+func NewFromFile(path string) (*File, error) {
+	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read config file: %w", err)
 	}
 
-	cfg = &File{
-		Path: file,
+	config := File{
+		Path: path,
+		Auth: AuthStorage{
+			StorageMode: "yaml",
+			Config: CustomMap{
+				"path": "./auth-storage.yaml",
+			},
+		},
 	}
-	err = yaml.Unmarshal(yamlFile, cfg)
-	if err != nil {
+
+	if err := yaml.Unmarshal(yamlFile, &config); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal config file: %w", err)
 	}
 
-	if cfg.Auth.StorageMode == "" {
-		cfg.Auth.StorageMode = "yaml"
-	}
-	if cfg.Auth.Config == nil {
-		cfg.Auth.Config = make(CustomMap)
-		cfg.Auth.Config["path"] = "./auth-storage.yaml"
-	}
-
-	return cfg, nil
+	return &config, nil
 }
 
 type AuthStorage struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,16 @@ func (suite *ConfigTestSuite) TestAuthStorageDefaultsFromFile() {
 	assert.Equal(suite.T(), "./auth-storage.yaml", sut.Auth.Config["path"])
 }
 
+func (suite *ConfigTestSuite) TestAuthStorageMixesFromFile() {
+	sut, err := config.NewFromFile("../../testdata/mixed_auth_storage.yaml")
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), sut)
+
+	assert.Equal(suite.T(), "yaml", sut.Auth.StorageMode)
+	assert.Equal(suite.T(), "./foo.mixed", sut.Auth.Config["path"])
+}
+
 func (suite *ConfigTestSuite) TestCustomAuthStorageFromFile() {
 	sut, err := config.NewFromFile("../../testdata/custom_auth_storage.yaml")
 

--- a/testdata/mixed_auth_storage.yaml
+++ b/testdata/mixed_auth_storage.yaml
@@ -1,0 +1,3 @@
+auth:
+  config:
+    path: "./foo.mixed"


### PR DESCRIPTION
Changed the validation mechanism to an initialised struct. 🚧