### PR TITLE
fix: deprecate the usage of the storage encryption key command line flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ make build
 ## To run without a build
 
 ```bash
-go run cmd/calendarsync/main.go --config <yourConfigFile> --storage-encryption-key <yourPasswordForTheLocalAuthFile>
+CALENDARSYNC_ENCRYPTION_KEY=<yourPasswordForTheLocalAuthFile> go run cmd/calendarsync/main.go --config <yourConfigFile>
 ```
 
 ## Git commit messages

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ data to a third party.
 # How to use
 
 Download the newest [release](https://github.com/inovex/CalendarSync/releases)
-for your platform or install from [the AUR](https://aur.archlinux.org/packages/calendarsync-bin), create a modified `sync.yaml` file based on the content of the `./example.sync.yaml` file. Finally, start the app using `./calendarsync --config sync.yaml --storage-encryption-key <YourSecretPassword>` and follow the instructions in the output.
+for your platform or install from [the AUR](https://aur.archlinux.org/packages/calendarsync-bin), create a modified `sync.yaml` file based on the content of the `./example.sync.yaml` file. Finally, start the app using `CALENDARSYNC_ENCRYPTION_KEY=<YourSecretPassword> ./calendarsync --config sync.yaml` and follow the instructions in the output.
 
 The app will create a file in the execution folder called `auth-storage.yaml`. In
 this file the OAuth2 Credentials will be saved encrypted by your
-`storage-encryption-key`.
+`$CALENDARSYNC_ENCRYPTION_KEY`.
 
 # Configuration
 

--- a/cmd/calendarsync/main.go
+++ b/cmd/calendarsync/main.go
@@ -49,7 +49,7 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:  flagStorageEncryptionKey,
-				Usage: "encryption string",
+				Usage: "encryption string to be used for encrypting the local auth-storage file. NOTE: This option is deprecated. Please use the CALENDARSYNC_ENCRYPTION_KEY env variable. The flag will be removed in later versions",
 			},
 			&cli.BoolFlag{
 				Name:  flagClean,
@@ -104,8 +104,19 @@ func Run(c *cli.Context) error {
 	}
 	log.Info("loaded config file", "path", cfg.Path)
 
+	if len(c.String(flagStorageEncryptionKey)) > 0 {
+		log.Warn("Parsing the encryption key using the flag is deprecated. Please use the environment variable $CALENDARSYNC_ENCRYPTION_KEY instead.")
+	} else {
+		if encKeyEnv, envSet := os.LookupEnv("CALENDARSYNC_ENCRYPTION_KEY"); envSet {
+			err := c.Set(flagStorageEncryptionKey, encKeyEnv)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	if len(c.String(flagStorageEncryptionKey)) == 0 {
-		return fmt.Errorf("flag --storage-encryption-key needs to be set")
+		return fmt.Errorf("Storage Encryption key needs to be set")
 	}
 
 	startTime, err := models.TimeFromConfig(cfg.Sync.StartTime)

--- a/cmd/calendarsync/main.go
+++ b/cmd/calendarsync/main.go
@@ -116,7 +116,7 @@ func Run(c *cli.Context) error {
 	}
 
 	if len(c.String(flagStorageEncryptionKey)) == 0 {
-		return fmt.Errorf("Storage Encryption key needs to be set")
+		return fmt.Errorf("storage encryption key needs to be set")
 	}
 
 	startTime, err := models.TimeFromConfig(cfg.Sync.StartTime)

--- a/docs/systemd-timers.md
+++ b/docs/systemd-timers.md
@@ -12,7 +12,8 @@ The following content should be placed under: `.config/systemd/user/CalendarSync
 Description=Run CalendarSync
 
 [Service]
-ExecStart=/path/to/binary/calendarsync --config path/to/your/sync.yaml --storage-encryption-key $key
+Environment=CALENDARSYNC_ENCRYPTION_KEY='supersecret'
+ExecStart=/path/to/binary/calendarsync --config path/to/your/sync.yaml 
 ```
 
 The following content should be placed under: `.config/systemd/user/CalendarSync.timer`


### PR DESCRIPTION
add warning and note to migrate to the env variable, as the flag will be removed in later versions
