### PR TITLE
feat: do tilde expansion for yaml storage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The app will create a file in the execution folder called `auth-storage.yaml`. I
 
 # Configuration
 
-The CalendarSync config file consists of `four` building blocks:
+The CalendarSync config file consists of several building blocks:
 
 - `sync` - Controls the timeframe to be synced
 - `source` - Controls the source calendar to be synced from
@@ -65,6 +65,7 @@ The CalendarSync config file consists of `four` building blocks:
 - `transformations` - Controls the transformers applied to the events before
   syncing
 - `filters` - Controls filters, which allow events to be excluded from syncing
+- `auth` - Controls settings regarding the encrypted auth storage file
 
 ## Sync
 
@@ -177,6 +178,19 @@ filters:
   - name: RegexTitle
     config:
       ExcludeRegexp: ".*test"
+```
+
+## Auth
+
+In this section you can configure settings regarding the encrypted local auth storage
+
+```yaml
+auth:
+  storage_mode: yaml # Currently, only yaml is supported
+  config:
+    # Here you can use the standard unix abbreviation for home directory (~).
+    # This works also for Windows systems e.g. ~\calendar-sync\auth-storage.yaml
+    path: "./auth-storage.yaml"
 ```
 
 # Cleaning Up

--- a/example.sync.yaml
+++ b/example.sync.yaml
@@ -8,8 +8,10 @@ sync:
     offset: +1 # MonthEnd +1 month (end of next month)
 
 auth:
-  storage_mode: yaml
+  storage_mode: yaml # Currently, only yaml is supported
   config:
+    # Here you can use the standard unix abbreviation for home directory (~).
+    # This works also for Windows systems e.g. ~\calendar-sync\auth-storage.yaml
     path: "./auth-storage.yaml"
 
 # Unfortunately, at this point, we only support one source adapter.

--- a/internal/auth/yaml_storage.go
+++ b/internal/auth/yaml_storage.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -26,8 +25,7 @@ type YamlStorage struct {
 func (y *YamlStorage) Setup(config config.AuthStorage, encryptionPassphrase string) error {
 	y.StorageEncryptionKey = encryptionPassphrase
 	y.StoragePath = config.Config["path"].(string)
-	if strings.HasPrefix(y.StoragePath, "~/") && (runtime.GOOS == "linux" || runtime.GOOS == "darwin") ||
-		strings.HasPrefix(y.StoragePath, "%userprofile%") && runtime.GOOS == "windows" {
+	if strings.HasPrefix(y.StoragePath, "~/") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return err

--- a/internal/auth/yaml_storage.go
+++ b/internal/auth/yaml_storage.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -25,7 +26,8 @@ type YamlStorage struct {
 func (y *YamlStorage) Setup(config config.AuthStorage, encryptionPassphrase string) error {
 	y.StorageEncryptionKey = encryptionPassphrase
 	y.StoragePath = config.Config["path"].(string)
-	if strings.HasPrefix(y.StoragePath, "~/") {
+	if strings.HasPrefix(y.StoragePath, "~/") && (runtime.GOOS == "linux" || runtime.GOOS == "darwin") ||
+		strings.HasPrefix(y.StoragePath, "%userprofile%") && runtime.GOOS == "windows" {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return err

--- a/internal/auth/yaml_storage.go
+++ b/internal/auth/yaml_storage.go
@@ -25,7 +25,7 @@ type YamlStorage struct {
 func (y *YamlStorage) Setup(config config.AuthStorage, encryptionPassphrase string) error {
 	y.StorageEncryptionKey = encryptionPassphrase
 	y.StoragePath = config.Config["path"].(string)
-	if strings.HasPrefix(y.StoragePath, "~/") {
+	if strings.HasPrefix(y.StoragePath, "~" + string(filepath.Separator)) {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return err

--- a/internal/auth/yaml_storage.go
+++ b/internal/auth/yaml_storage.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/inovex/CalendarSync/internal/config"
@@ -113,6 +116,10 @@ func (y *YamlStorage) RemoveCalendarAuth(calendarID string) error {
 
 func (y *YamlStorage) writeFile(cals []CalendarAuth) error {
 	var writer io.Writer
+	if strings.HasPrefix(y.StoragePath, "~/") {
+		usr, _ := user.Current()
+		y.StoragePath = filepath.Join(usr.HomeDir, y.StoragePath[2:])
+	}
 	file, err := os.OpenFile(y.StoragePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open storage file: %w", err)


### PR DESCRIPTION
Allow the path to the auth storage to start with a tilde and expand it to the home directory of the user executing the program.

If it doesn't start with a tilde, the current behaviour is kept.