### PR TITLE
Fix test failure

### DIFF
--- a/internal/sync/controller_test.go
+++ b/internal/sync/controller_test.go
@@ -525,6 +525,7 @@ func (suite *ControllerTestSuite) TestCreateEventsDeclined() {
 	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(eventsToCreate, nil)
 	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(nil, nil)
 	suite.sink.On("CreateEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
+	suite.sink.On("GetCalendarID").Return("sinkID")
 
 	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, false)
 	assert.NoError(suite.T(), err)


### PR DESCRIPTION
Synchronizing an event now requires calling `GetCalendarID()` on the sink. This requirement was concurrently introduced by the commit
`feat: do not resurrect event when syncing in both directions` #67  which conflicts with `feat: Implement option to enable / disable sync of declined events` #62 .