### PR TITLE
docs: adds asdf-calendarsync plugin documentation as a new installati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,29 @@ data to a third party.
 
 # How to use
 
-Download the newest [release](https://github.com/inovex/CalendarSync/releases)
-for your platform or install from [the AUR](https://aur.archlinux.org/packages/calendarsync-bin), create a modified `sync.yaml` file based on the content of the `./example.sync.yaml` file. Finally, start the app using `CALENDARSYNC_ENCRYPTION_KEY=<YourSecretPassword> ./calendarsync --config sync.yaml` and follow the instructions in the output.
+## Installation
 
-The app will create a file in the execution folder called `auth-storage.yaml`. In
-this file the OAuth2 Credentials will be saved encrypted by your
-`$CALENDARSYNC_ENCRYPTION_KEY`.
+Download the newest [release](https://github.com/inovex/CalendarSync/releases) for your platform or install from [the AUR](https://aur.archlinux.org/packages/calendarsync-bin).
+
+**Using [asdf-vm](https://github.com/asdf-vm/asdf)**
+
+You can also install this program using `asdf-vm`.
+
+```sh
+asdf plugin add calendarsync
+# or
+asdf plugin add calendarsync https://github.com/FeryET/asdf-calendarsync.git
+## finally
+asdf install calendarsync
+```
+
+## First Time Execution
+
+Create a modified `sync.yaml` file based on the content of the `./example.sync.yaml` file. Finally, start the app using `CALENDARSYNC_ENCRYPTION_KEY=<YourSecretPassword> ./calendarsync --config sync.yaml` and follow the instructions in the output.
+
+The app will create a file in the execution folder called `auth-storage.yaml`. In this file the OAuth2 Credentials will be saved encrypted by your `$CALENDARSYNC_ENCRYPTION_KEY`.
+
+----
 
 # Configuration
 


### PR DESCRIPTION
This pull request adds a tiny bit of documentation for installation of `CalendarSync` using a plugin for `asdf-vm`. 