### PR TITLE
feat: add flag to not open the browser automatically

### DIFF
--- a/cmd/calendarsync/main.go
+++ b/cmd/calendarsync/main.go
@@ -17,13 +17,14 @@ import (
 )
 
 const (
-	flagLogLevel             = "log-level"
-	flagConfigFilePath       = "config"
-	flagStorageEncryptionKey = "storage-encryption-key"
-	flagClean                = "clean"
-	flagDryRun               = "dry-run"
-	flagPort                 = "port"
-	flagVersion              = "version"
+	flagLogLevel                 = "log-level"
+	flagConfigFilePath           = "config"
+	flagStorageEncryptionKey     = "storage-encryption-key"
+	flagClean                    = "clean"
+	flagDryRun                   = "dry-run"
+	flagPort                     = "port"
+	flagOpenBrowserAutomatically = "open-browser"
+	flagVersion                  = "version"
 )
 
 var (
@@ -50,6 +51,11 @@ func main() {
 			&cli.StringFlag{
 				Name:  flagStorageEncryptionKey,
 				Usage: "encryption string to be used for encrypting the local auth-storage file. NOTE: This option is deprecated. Please use the CALENDARSYNC_ENCRYPTION_KEY env variable. The flag will be removed in later versions",
+			},
+			&cli.BoolFlag{
+				Name:  flagOpenBrowserAutomatically,
+				Usage: "opens the browser automatically for the authentication process",
+				Value: true,
 			},
 			&cli.BoolFlag{
 				Name:  flagClean,
@@ -149,6 +155,7 @@ func Run(c *cli.Context) error {
 	sourceAdapter, err := adapter.NewSourceAdapterFromConfig(
 		c.Context,
 		sourceBindAuthPort,
+		c.Bool(flagOpenBrowserAutomatically),
 		config.NewAdapterConfig(cfg.Source.Adapter),
 		storage,
 		sourceLogger,
@@ -163,6 +170,7 @@ func Run(c *cli.Context) error {
 	sinkAdapter, err := adapter.NewSinkAdapterFromConfig(
 		c.Context,
 		sinkBindAuthPort,
+		c.Bool(flagOpenBrowserAutomatically),
 		config.NewAdapterConfig(cfg.Sink.Adapter),
 		storage,
 		sinkLogger,

--- a/internal/adapter/google/client.go
+++ b/internal/adapter/google/client.go
@@ -197,7 +197,6 @@ func (g *GCalClient) DeleteEvent(ctx context.Context, event models.Event) error 
 		return err
 	}
 	return nil
-
 }
 
 // loadPages recursively loads all pages starting with the given nextPageToken.

--- a/internal/adapter/outlook_http/adapter.go
+++ b/internal/adapter/outlook_http/adapter.go
@@ -161,20 +161,25 @@ func (c *CalendarAPI) SetupOauth2(ctx context.Context, credentials auth.Credenti
 	return nil
 }
 
-func (c *CalendarAPI) Initialize(ctx context.Context, config map[string]interface{}) error {
+func (c *CalendarAPI) Initialize(ctx context.Context, openBrowser bool, config map[string]interface{}) error {
 	if !c.authenticated {
 		c.oAuthUrl = c.oAuthHandler.Configuration().AuthCodeURL("state", oauth2.AccessTypeOffline)
-		c.logger.Infof("opening browser window for authentication of %s\n", c.Name())
-		err := browser.OpenURL(c.oAuthUrl)
-		if err != nil {
-			c.logger.Infof("browser did not open, please authenticate adapter %s:\n\n %s\n\n\n", c.Name(), c.oAuthUrl)
+
+		if openBrowser {
+			c.logger.Infof("opening browser window for authentication of %s\n", c.Name())
+			err := browser.OpenURL(c.oAuthUrl)
+			if err != nil {
+				c.logger.Infof("browser did not open, please authenticate adapter %s:\n\n %s\n\n\n", c.Name(), c.oAuthUrl)
+			}
+		} else {
+			c.logger.Infof("Please authenticate adapter %s:\n\n %s\n\n\n", c.Name(), c.oAuthUrl)
 		}
 		if err := c.oAuthHandler.Listen(ctx); err != nil {
 			return err
 		}
 
 		c.oAuthToken = c.oAuthHandler.Token()
-		_, err = c.storage.WriteCalendarAuth(auth.CalendarAuth{
+		_, err := c.storage.WriteCalendarAuth(auth.CalendarAuth{
 			CalendarID: c.calendarID,
 			OAuth2: auth.OAuth2Object{
 				AccessToken:  c.oAuthToken.AccessToken,

--- a/internal/adapter/port/interface.go
+++ b/internal/adapter/port/interface.go
@@ -16,7 +16,7 @@ type LogSetter interface {
 // Configurable is an interface which defines how arbitrary configuration data can be passed
 // to a struct which implements this interface. Clients should be configurable.
 type Configurable interface {
-	Initialize(ctx context.Context, config map[string]interface{}) error
+	Initialize(ctx context.Context, openBrowser bool, config map[string]interface{}) error
 }
 
 type OAuth2Adapter interface {

--- a/internal/adapter/sink_adapter.go
+++ b/internal/adapter/sink_adapter.go
@@ -35,7 +35,7 @@ func SinkClientFactory(typ Type) (sync.Sink, error) {
 	}
 }
 
-func NewSinkAdapterFromConfig(ctx context.Context, bindPort uint, config ConfigReader, storage auth.Storage, logger *log.Logger) (*SinkAdapter, error) {
+func NewSinkAdapterFromConfig(ctx context.Context, bindPort uint, openBrowser bool, config ConfigReader, storage auth.Storage, logger *log.Logger) (*SinkAdapter, error) {
 	client, err := SinkClientFactory(Type(config.Adapter().Type))
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func NewSinkAdapterFromConfig(ctx context.Context, bindPort uint, config ConfigR
 
 	// configure adapter client if possible
 	if c, ok := client.(port.Configurable); ok {
-		if err := c.Initialize(ctx, config.Adapter().Config); err != nil {
+		if err := c.Initialize(ctx, openBrowser, config.Adapter().Config); err != nil {
 			return nil, fmt.Errorf("unable to Initialize adapter %s: %w", config.Adapter().Type, err)
 		}
 	}

--- a/internal/adapter/source_adapter.go
+++ b/internal/adapter/source_adapter.go
@@ -38,7 +38,7 @@ type SourceAdapter struct {
 	logger     *log.Logger
 }
 
-func NewSourceAdapterFromConfig(ctx context.Context, bindPort uint, config ConfigReader, storage auth.Storage, logger *log.Logger) (*SourceAdapter, error) {
+func NewSourceAdapterFromConfig(ctx context.Context, bindPort uint, openBrowser bool, config ConfigReader, storage auth.Storage, logger *log.Logger) (*SourceAdapter, error) {
 	var client sync.Source
 	client, err := SourceClientFactory(Type(config.Adapter().Type))
 	if err != nil {
@@ -70,7 +70,7 @@ func NewSourceAdapterFromConfig(ctx context.Context, bindPort uint, config Confi
 
 	// configure adapter client if possible
 	if c, ok := client.(port.Configurable); ok {
-		if err := c.Initialize(ctx, config.Adapter().Config); err != nil {
+		if err := c.Initialize(ctx, openBrowser, config.Adapter().Config); err != nil {
 			return nil, fmt.Errorf("unable to initialize adapter %s: %w", config.Adapter().Type, err)
 		}
 	}

--- a/internal/adapter/zep/client.go
+++ b/internal/adapter/zep/client.go
@@ -58,7 +58,7 @@ func (zep *CalendarAPI) Name() string {
 	return "ZEP CalDav API"
 }
 
-func (zep *CalendarAPI) Initialize(ctx context.Context, config map[string]interface{}) error {
+func (zep *CalendarAPI) Initialize(ctx context.Context, openBrowser bool, config map[string]interface{}) error {
 	if _, ok := config[usernameKey]; !ok {
 		return fmt.Errorf("missing config key: %s", usernameKey)
 	}


### PR DESCRIPTION
Sometimes i want to authenticate using an incognito window, but calendarsync opens the auth dialog in the last recent window i used. To make sure i can select which browser, window or profile i want to use for the authentication, i can now add the flag `--open-browser false` to get a link which can be copied to the browser or window the user selects. 
