### PR TITLE
fix: allow ugc content in keepDescription transformer

### DIFF
--- a/internal/transformation/keepDescription.go
+++ b/internal/transformation/keepDescription.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 
 	"github.com/aquilax/truncate"
-	"github.com/microcosm-cc/bluemonday"
 	"github.com/inovex/CalendarSync/internal/models"
+	"github.com/microcosm-cc/bluemonday"
 )
 
 // KeepDescription allows to keep the description of an event.
@@ -16,8 +16,8 @@ func (t *KeepDescription) Name() string {
 }
 
 func (t *KeepDescription) Transform(source models.Event, sink models.Event) (models.Event, error) {
-	// need to remove microsoft html overhead
-	p := bluemonday.StrictPolicy()
+	// need to remove microsoft html overhead (the description in outlook contains a lot of '\r\n's)
+	p := bluemonday.UGCPolicy()
 	description := strings.ReplaceAll(source.Description, "\r\n", "")
 	sanitizedDescription := p.Sanitize(description)
 	sanitizedDescription2 := strings.TrimSpace(sanitizedDescription)

--- a/internal/transformation/keepDescription_test.go
+++ b/internal/transformation/keepDescription_test.go
@@ -1,10 +1,11 @@
 package transformation
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/inovex/CalendarSync/internal/models"
 	"strings"
 	"testing"
+
+	"github.com/inovex/CalendarSync/internal/models"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestKeepDescription_Transform(t *testing.T) {
@@ -40,9 +41,9 @@ func TestKeepDescription_Transform(t *testing.T) {
 		},
 		{
 			name:                "removes html from description",
-			sourceDescription:   "<h1>Headline</h1>",
+			sourceDescription:   "<test>Headline</test><h1>Headline2</h1>",
 			sinkDescription:     "bar",
-			expectedDescription: "Headline",
+			expectedDescription: "Headline<h1>Headline2</h1>",
 		},
 		{
 			name:                "truncates description after 4000 chars",

--- a/internal/transformation/keepDescription_test.go
+++ b/internal/transformation/keepDescription_test.go
@@ -46,6 +46,12 @@ func TestKeepDescription_Transform(t *testing.T) {
 			expectedDescription: "Headline<h1>Headline2</h1>",
 		},
 		{
+			name:                "keep html-linebreaks from description",
+			sourceDescription:   "<h1>Headline2</h1><br><br/>ohai\r\n",
+			sinkDescription:     "bar",
+			expectedDescription: "<h1>Headline2</h1><br><br/>ohai",
+		},
+		{
 			name:                "truncates description after 4000 chars",
 			sourceDescription:   strings.Repeat("a", 4000),
 			sinkDescription:     "bar",


### PR DESCRIPTION
This makes the kept description more readable if the source content is in html. 

thanks @frittentheke for bringing attention to this. 🙏🏼

fixes #176 