### PR TITLE
outlook: fix temporary memory leak while listing events

### DIFF
--- a/internal/adapter/outlook_http/client.go
+++ b/internal/adapter/outlook_http/client.go
@@ -46,7 +46,7 @@ func (o *OutlookClient) ListEvents(ctx context.Context, start time.Time, end tim
 	}
 
 	body, _ := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
+	resp.Body.Close()
 
 	var eventList EventList
 	err = json.Unmarshal(body, &eventList)
@@ -62,7 +62,7 @@ func (o *OutlookClient) ListEvents(ctx context.Context, start time.Time, end tim
 		}
 
 		body, _ := io.ReadAll(resp.Body)
-		defer resp.Body.Close()
+		resp.Body.Close()
 
 		var nextList EventList
 		err = json.Unmarshal(body, &nextList)


### PR DESCRIPTION
As the whole request body is read using io.ReadAll, thus the request can be freed immediately afterwards.

Might help with https://github.com/inovex/CalendarSync/issues/180 .