### PR TITLE
Disable -race build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: help
 ## Build
 build: ## Build CalendarSync
 	@mkdir -p bin
-	$(GO) build -race -ldflags \
+	$(GO) build -ldflags \
 		"-X 'main.Version=$(BUILD_VERSION)' \
 		-X 'main.BuildTime=$(shell date)' \
 		-X 'main.GoogleClientID=${CS_GOOGLE_CLIENT_ID}' \


### PR DESCRIPTION
Enabling data race detection should be sufficient for release builds.

Helps with https://github.com/inovex/CalendarSync/issues/180 when building from source. Release builds never used that flag.