### PR TITLE
keepDescription: initialize bluemonday policy only once

### DIFF
--- a/internal/transformation/keepDescription.go
+++ b/internal/transformation/keepDescription.go
@@ -2,6 +2,7 @@ package transformation
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/aquilax/truncate"
 	"github.com/inovex/CalendarSync/internal/models"
@@ -9,17 +10,23 @@ import (
 )
 
 // KeepDescription allows to keep the description of an event.
-type KeepDescription struct{}
+type KeepDescription struct {
+	policy     *bluemonday.Policy
+	initPolicy sync.Once
+}
 
 func (t *KeepDescription) Name() string {
 	return "KeepDescription"
 }
 
 func (t *KeepDescription) Transform(source models.Event, sink models.Event) (models.Event, error) {
+	t.initPolicy.Do(func() {
+		t.policy = bluemonday.UGCPolicy()
+	})
+
 	// need to remove microsoft html overhead (the description in outlook contains a lot of '\r\n's)
-	p := bluemonday.UGCPolicy()
 	description := strings.ReplaceAll(source.Description, "\r\n", "")
-	sanitizedDescription := p.Sanitize(description)
+	sanitizedDescription := t.policy.Sanitize(description)
 	sanitizedDescription2 := strings.TrimSpace(sanitizedDescription)
 
 	// Since the description cannot exceed a specified amount in some sinks (e.g. google)


### PR DESCRIPTION
The policy can be reused, thus there's no need to recreate it for every processed calendar event.

Inspired by https://github.com/inovex/CalendarSync/issues/180 . But this barely changes the memory usage.