### PR TITLE
refactor: rename GetCalendarID to GetCalendarHash

### DIFF
--- a/internal/adapter/google/adapter.go
+++ b/internal/adapter/google/adapter.go
@@ -25,7 +25,7 @@ type GoogleCalendarClient interface {
 	CreateEvent(ctx context.Context, event models.Event) error
 	UpdateEvent(ctx context.Context, event models.Event) error
 	DeleteEvent(ctx context.Context, event models.Event) error
-	GetCalendarID() string
+	GetCalendarHash() string
 	InitGoogleCalendarClient(calId string, log *log.Logger) error
 }
 
@@ -226,12 +226,12 @@ func (c *CalendarAPI) Name() string {
 	return "Google Calendar"
 }
 
-// GetCalendarID calculates a unique ID for this adapter based on the current calendar.
+// GetCalendarHash calculates a unique hash for this adapter based on the current calendar.
 // This is used to distinguish between adapters in order to not overwrite or delete events
 // which are maintained by different adapters.
 // A simple use-case for this is if you have multiple google calendars as source adapters configured.
-func (c *CalendarAPI) GetCalendarID() string {
-	return c.gcalClient.GetCalendarID()
+func (c *CalendarAPI) GetCalendarHash() string {
+	return c.gcalClient.GetCalendarHash()
 }
 
 func (c *CalendarAPI) SetLogger(logger *log.Logger) {

--- a/internal/adapter/google/client.go
+++ b/internal/adapter/google/client.go
@@ -70,7 +70,7 @@ func (g *GCalClient) ListEvents(ctx context.Context, starttime time.Time, endtim
 
 	var loadedEvents []models.Event
 	for _, event := range eventList.Items {
-		loadedEvents = append(loadedEvents, calendarEventToEvent(event, g.GetCalendarID()))
+		loadedEvents = append(loadedEvents, calendarEventToEvent(event, g.GetCalendarHash()))
 	}
 
 	// if the responses 'nextPageToken' is set, the result is paginated and more data to be loaded recursively
@@ -80,7 +80,7 @@ func (g *GCalClient) ListEvents(ctx context.Context, starttime time.Time, endtim
 			return nil, err
 		}
 		for _, pageEvent := range eventList.Items {
-			loadedEvents = append(loadedEvents, calendarEventToEvent(pageEvent, g.GetCalendarID()))
+			loadedEvents = append(loadedEvents, calendarEventToEvent(pageEvent, g.GetCalendarHash()))
 		}
 	}
 	return loadedEvents, nil
@@ -216,11 +216,11 @@ func (g *GCalClient) loadPages(listCall *calendar.EventsListCall, events *[]*cal
 	return g.loadPages(listCall, events, pageEvents.NextPageToken)
 }
 
-// GetCalendarID calculates a unique ID for this adapter based on the current calendar.
+// GetCalendarHash calculates a unique ID for this adapter based on the current calendar.
 // This is used to distinguish between adapters in order to not overwrite or delete events
 // which are maintained by different adapters.
 // A simple use-case for this is if you have multiple google calendars as source adapters configured.
-func (g *GCalClient) GetCalendarID() string {
+func (g *GCalClient) GetCalendarHash() string {
 	var id []byte
 
 	sum := sha1.Sum([]byte(g.CalendarId))

--- a/internal/adapter/outlook_http/adapter.go
+++ b/internal/adapter/outlook_http/adapter.go
@@ -24,7 +24,7 @@ type OutlookCalendarClient interface {
 	CreateEvent(ctx context.Context, event models.Event) error
 	UpdateEvent(ctx context.Context, event models.Event) error
 	DeleteEvent(ctx context.Context, event models.Event) error
-	GetCalendarID() string
+	GetCalendarHash() string
 }
 
 type CalendarAPI struct {
@@ -245,8 +245,8 @@ func (c *CalendarAPI) DeleteEvent(ctx context.Context, e models.Event) error {
 	return nil
 }
 
-func (c *CalendarAPI) GetCalendarID() string {
-	return c.outlookClient.GetCalendarID()
+func (c *CalendarAPI) GetCalendarHash() string {
+	return c.outlookClient.GetCalendarHash()
 }
 
 func (c *CalendarAPI) Name() string {

--- a/internal/adapter/outlook_http/client.go
+++ b/internal/adapter/outlook_http/client.go
@@ -84,7 +84,7 @@ func (o *OutlookClient) ListEvents(ctx context.Context, start time.Time, end tim
 
 	var events []models.Event
 	for _, evt := range eventList.Events {
-		evt, err := o.outlookEventToEvent(evt, o.GetCalendarID())
+		evt, err := o.outlookEventToEvent(evt, o.GetCalendarHash())
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func (o *OutlookClient) DeleteEvent(ctx context.Context, event models.Event) err
 	return nil
 }
 
-func (o OutlookClient) GetCalendarID() string {
+func (o OutlookClient) GetCalendarHash() string {
 	var id []byte
 	sum := sha1.Sum([]byte(o.CalendarID))
 	id = append(id, sum[:]...)

--- a/internal/adapter/sink_adapter.go
+++ b/internal/adapter/sink_adapter.go
@@ -104,6 +104,6 @@ func (a SinkAdapter) EventsInTimeframe(ctx context.Context, start time.Time, end
 	return a.client.EventsInTimeframe(ctx, start, end)
 }
 
-func (a SinkAdapter) GetCalendarID() string {
-	return a.client.GetCalendarID()
+func (a SinkAdapter) GetCalendarHash() string {
+	return a.client.GetCalendarHash()
 }

--- a/internal/adapter/source_adapter.go
+++ b/internal/adapter/source_adapter.go
@@ -91,8 +91,8 @@ func (a SourceAdapter) Name() string {
 func (a SourceAdapter) CalendarID() string {
 	return a.calendarID
 }
-func (a SourceAdapter) GetCalendarID() string {
-	return a.client.GetCalendarID()
+func (a SourceAdapter) GetCalendarHash() string {
+	return a.client.GetCalendarHash()
 }
 
 func (a SourceAdapter) EventsInTimeframe(ctx context.Context, start time.Time, end time.Time) ([]models.Event, error) {

--- a/internal/adapter/zep/client.go
+++ b/internal/adapter/zep/client.go
@@ -40,18 +40,13 @@ type CalendarAPI struct {
 // Assert that the expected interfaces are implemented
 var _ port.Configurable = &CalendarAPI{}
 
-func (zep *CalendarAPI) GetCalendarID() string {
-	return zep.generateCalendarID()
-}
-
-func (zep *CalendarAPI) generateCalendarID() string {
+func (zep *CalendarAPI) GetCalendarHash() string {
 	var id []byte
 	components := []string{zep.username, zep.homeSet, zep.calendarID}
 
 	sum := sha1.Sum([]byte(strings.Join(components, "")))
 	id = append(id, sum[:]...)
 	return base64.URLEncoding.EncodeToString(id)
-
 }
 
 func (zep *CalendarAPI) Name() string {
@@ -109,7 +104,7 @@ func (zep *CalendarAPI) EventsInTimeframe(ctx context.Context, start time.Time, 
 				StartTime:   v.Start,
 				EndTime:     v.End,
 				Accepted:    true,
-				Metadata:    models.NewEventMetadata(v.ID, "", zep.GetCalendarID()),
+				Metadata:    models.NewEventMetadata(v.ID, "", zep.GetCalendarHash()),
 			})
 	}
 

--- a/internal/models/metadata.go
+++ b/internal/models/metadata.go
@@ -12,7 +12,7 @@ type Metadata struct {
 	SyncID string `json:"SyncID"`
 	// OriginalEventUri is an URI which points to the original event which was synced. This is usually an URL.
 	OriginalEventUri string `json:"OriginalEventUri"`
-	// SourceID contains the ID of the source which this event was imported from
+	// SourceID contains the unique hash of the source which this event was imported from
 	SourceID string `json:"SourceID"`
 }
 

--- a/internal/sync/controller.go
+++ b/internal/sync/controller.go
@@ -159,7 +159,7 @@ func (p Controller) CleanUp(ctx context.Context, start time.Time, end time.Time)
 	for _, event := range sink {
 		// Check if the sink event was synced by us, if there's no metadata the event may
 		// be there because we were invited or because it is not managed by us
-		if event.Metadata.SourceID == p.source.GetCalendarID() {
+		if event.Metadata.SourceID == p.source.GetCalendarHash() {
 			// redefine to let the closure capture individual variables
 			event := event
 			tasks = append(tasks, func() error {
@@ -201,18 +201,18 @@ func (p Controller) diffEvents(sourceEvents []models.Event, sinkEvents []models.
 			// - Run sync from calendar B to calendar A. This will copy (and thereby resurrect) the event.
 			//
 			// Solution: Ignore events the originate from the sink, but no longer exist there.
-			if event.Metadata.SourceID == p.sink.GetCalendarID() {
+			if event.Metadata.SourceID == p.sink.GetCalendarHash() {
 				p.logger.Info("skipping event as it originates from the sink, but no longer exists there", logFields(event)...)
 				continue
 			}
 			p.logger.Info("new event, needs sync", logFields(event)...)
 			createEvents = append(createEvents, event)
 
-		case sinkEvent.Metadata.SourceID != p.source.GetCalendarID():
+		case sinkEvent.Metadata.SourceID != p.source.GetCalendarHash():
 			p.logger.Info("event was not synced by this source adapter, skipping", logFields(event)...)
 
 			// Only update the event if the event differs AND we synced it prior and set the correct metadata
-		case !models.IsSameEvent(event, sinkEvent) && sinkEvent.Metadata.SourceID == p.source.GetCalendarID():
+		case !models.IsSameEvent(event, sinkEvent) && sinkEvent.Metadata.SourceID == p.source.GetCalendarHash():
 			p.logger.Info("event content changed, needs sync", logFields(event)...)
 			updateEvents = append(updateEvents, sinkEvent.Overwrite(event))
 
@@ -231,7 +231,7 @@ func (p Controller) diffEvents(sourceEvents []models.Event, sinkEvents []models.
 		case exists:
 			// Nothing to do
 
-		case event.Metadata.SourceID == p.source.GetCalendarID():
+		case event.Metadata.SourceID == p.source.GetCalendarHash():
 			p.logger.Info("sinkEvent is not (anymore) in sourceEvents, marked for removal", logFields(event)...)
 			deleteEvents = append(deleteEvents, event)
 

--- a/internal/sync/controller_test.go
+++ b/internal/sync/controller_test.go
@@ -99,8 +99,8 @@ func (suite *ControllerTestSuite) TestDryRun() {
 	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(sourceEvents, nil)
 	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(sinkEvents, nil)
 	suite.sink.On("DeleteEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
-	suite.sink.On("GetCalendarID").Return("sinkID")
-	suite.source.On("GetCalendarID").Return("sourceID")
+	suite.sink.On("GetCalendarHash").Return("sinkID")
+	suite.source.On("GetCalendarHash").Return("sourceID")
 
 	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, true)
 	assert.NoError(suite.T(), err)
@@ -176,8 +176,8 @@ func (suite *ControllerTestSuite) TestCleanUp() {
 	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(sourceEvents, nil)
 	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(sinkEvents, nil)
 	suite.sink.On("DeleteEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
-	suite.sink.On("GetCalendarID").Return("sinkID")
-	suite.source.On("GetCalendarID").Return("sourceID")
+	suite.sink.On("GetCalendarHash").Return("sinkID")
+	suite.source.On("GetCalendarHash").Return("sourceID")
 
 	err := suite.controller.CleanUp(ctx, startTime, endTime)
 	assert.NoError(suite.T(), err)
@@ -222,7 +222,7 @@ func (suite *ControllerTestSuite) TestCreateEventsEmptySink() {
 	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(eventsToCreate, nil)
 	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(nil, nil)
 	suite.sink.On("CreateEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
-	suite.sink.On("GetCalendarID").Return("sinkID")
+	suite.sink.On("GetCalendarHash").Return("sinkID")
 
 	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, false)
 	assert.NoError(suite.T(), err)
@@ -307,8 +307,8 @@ func (suite *ControllerTestSuite) TestDeleteEventsNotInSink() {
 	suite.sink.On("DeleteEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
 	// UpdateEvent gets called because the remaining event in the sink will get updated because there are no transformers configured
 	suite.sink.On("UpdateEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
-	suite.sink.On("GetCalendarID").Return("sinkID")
-	suite.source.On("GetCalendarID").Return("sourceID")
+	suite.sink.On("GetCalendarHash").Return("sinkID")
+	suite.source.On("GetCalendarHash").Return("sourceID")
 
 	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, false)
 	assert.NoError(suite.T(), err)
@@ -344,8 +344,8 @@ func (suite *ControllerTestSuite) TestDoNotResurrectEvents() {
 
 	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(sourceEvents, nil)
 	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(sinkEvents, nil)
-	suite.sink.On("GetCalendarID").Return("sinkID")
-	suite.source.On("GetCalendarID").Return("sourceID")
+	suite.sink.On("GetCalendarHash").Return("sinkID")
+	suite.source.On("GetCalendarHash").Return("sourceID")
 
 	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, false)
 	assert.NoError(suite.T(), err)
@@ -478,8 +478,8 @@ func (suite *ControllerTestSuite) TestUpdateEventsPrefilledSink() {
 	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(sourceEvents, nil)
 	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(sinkEvents, nil)
 	suite.sink.On("UpdateEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
-	suite.sink.On("GetCalendarID").Return("sinkID")
-	suite.source.On("GetCalendarID").Return("sourceID")
+	suite.sink.On("GetCalendarHash").Return("sinkID")
+	suite.source.On("GetCalendarHash").Return("sourceID")
 
 	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, false)
 	assert.NoError(suite.T(), err)
@@ -525,7 +525,7 @@ func (suite *ControllerTestSuite) TestCreateEventsDeclined() {
 	suite.source.On("EventsInTimeframe", ctx, startTime, endTime).Return(eventsToCreate, nil)
 	suite.sink.On("EventsInTimeframe", ctx, startTime, endTime).Return(nil, nil)
 	suite.sink.On("CreateEvent", ctx, mock.AnythingOfType("models.Event")).Return(nil)
-	suite.sink.On("GetCalendarID").Return("sinkID")
+	suite.sink.On("GetCalendarHash").Return("sinkID")
 
 	err := suite.controller.SynchroniseTimeframe(ctx, startTime, endTime, false)
 	assert.NoError(suite.T(), err)
@@ -769,10 +769,10 @@ func TestController_diffEvents(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			var source mocks.Source
-			source.On("GetCalendarID").Return("sourceID")
+			source.On("GetCalendarHash").Return("sourceID")
 
 			var sink mocks.Sink
-			sink.On("GetCalendarID").Return("sinkID")
+			sink.On("GetCalendarHash").Return("sinkID")
 
 			var controller = Controller{
 				source: &source,

--- a/internal/sync/mocks/Sink.go
+++ b/internal/sync/mocks/Sink.go
@@ -178,12 +178,12 @@ func (_c *Sink_EventsInTimeframe_Call) RunAndReturn(run func(context.Context, ti
 	return _c
 }
 
-// GetCalendarID provides a mock function with given fields:
-func (_m *Sink) GetCalendarID() string {
+// GetCalendarHash provides a mock function with given fields:
+func (_m *Sink) GetCalendarHash() string {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetCalendarID")
+		panic("no return value specified for GetCalendarHash")
 	}
 
 	var r0 string
@@ -196,29 +196,29 @@ func (_m *Sink) GetCalendarID() string {
 	return r0
 }
 
-// Sink_GetCalendarID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCalendarID'
-type Sink_GetCalendarID_Call struct {
+// Sink_GetCalendarHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCalendarHash'
+type Sink_GetCalendarHash_Call struct {
 	*mock.Call
 }
 
-// GetCalendarID is a helper method to define mock.On call
-func (_e *Sink_Expecter) GetCalendarID() *Sink_GetCalendarID_Call {
-	return &Sink_GetCalendarID_Call{Call: _e.mock.On("GetCalendarID")}
+// GetCalendarHash is a helper method to define mock.On call
+func (_e *Sink_Expecter) GetCalendarHash() *Sink_GetCalendarHash_Call {
+	return &Sink_GetCalendarHash_Call{Call: _e.mock.On("GetCalendarHash")}
 }
 
-func (_c *Sink_GetCalendarID_Call) Run(run func()) *Sink_GetCalendarID_Call {
+func (_c *Sink_GetCalendarHash_Call) Run(run func()) *Sink_GetCalendarHash_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *Sink_GetCalendarID_Call) Return(_a0 string) *Sink_GetCalendarID_Call {
+func (_c *Sink_GetCalendarHash_Call) Return(_a0 string) *Sink_GetCalendarHash_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Sink_GetCalendarID_Call) RunAndReturn(run func() string) *Sink_GetCalendarID_Call {
+func (_c *Sink_GetCalendarHash_Call) RunAndReturn(run func() string) *Sink_GetCalendarHash_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/sync/mocks/Source.go
+++ b/internal/sync/mocks/Source.go
@@ -84,12 +84,12 @@ func (_c *Source_EventsInTimeframe_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
-// GetCalendarID provides a mock function with given fields:
-func (_m *Source) GetCalendarID() string {
+// GetCalendarHash provides a mock function with given fields:
+func (_m *Source) GetCalendarHash() string {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetCalendarID")
+		panic("no return value specified for GetCalendarHash")
 	}
 
 	var r0 string
@@ -102,29 +102,29 @@ func (_m *Source) GetCalendarID() string {
 	return r0
 }
 
-// Source_GetCalendarID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCalendarID'
-type Source_GetCalendarID_Call struct {
+// Source_GetCalendarHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCalendarHash'
+type Source_GetCalendarHash_Call struct {
 	*mock.Call
 }
 
-// GetCalendarID is a helper method to define mock.On call
-func (_e *Source_Expecter) GetCalendarID() *Source_GetCalendarID_Call {
-	return &Source_GetCalendarID_Call{Call: _e.mock.On("GetCalendarID")}
+// GetCalendarHash is a helper method to define mock.On call
+func (_e *Source_Expecter) GetCalendarHash() *Source_GetCalendarHash_Call {
+	return &Source_GetCalendarHash_Call{Call: _e.mock.On("GetCalendarHash")}
 }
 
-func (_c *Source_GetCalendarID_Call) Run(run func()) *Source_GetCalendarID_Call {
+func (_c *Source_GetCalendarHash_Call) Run(run func()) *Source_GetCalendarHash_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *Source_GetCalendarID_Call) Return(_a0 string) *Source_GetCalendarID_Call {
+func (_c *Source_GetCalendarHash_Call) Return(_a0 string) *Source_GetCalendarHash_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Source_GetCalendarID_Call) RunAndReturn(run func() string) *Source_GetCalendarID_Call {
+func (_c *Source_GetCalendarHash_Call) RunAndReturn(run func() string) *Source_GetCalendarHash_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/sync/synchronisation.go
+++ b/internal/sync/synchronisation.go
@@ -22,7 +22,7 @@ type Source interface {
 	NamedComponent
 	// EventsInTimeframe return all events in a certain timeframe
 	EventsInTimeframe(ctx context.Context, start time.Time, end time.Time) ([]models.Event, error)
-	GetCalendarID() string
+	GetCalendarHash() string
 }
 
 // Sink describes a NamedComponent allows write-access to events.
@@ -36,5 +36,5 @@ type Sink interface {
 	UpdateEvent(ctx context.Context, e models.Event) error
 	// DeleteEvent deletes the given Event in the external calendar
 	DeleteEvent(ctx context.Context, e models.Event) error
-	GetCalendarID() string
+	GetCalendarHash() string
 }


### PR DESCRIPTION
When reading the code, I was confused about `GetCalendarID` function and the `calendarID` field, assuming they represent the same value. As this is not the case, and `GetCalendarID` returns a unique hash for a calendar, I renamed it to `GetCalendarHash`.