### PR TITLE
Small fixes for all-day events

### DIFF
--- a/internal/filter/timeFrame.go
+++ b/internal/filter/timeFrame.go
@@ -14,6 +14,11 @@ func (a TimeFrameEvents) Name() string {
 }
 
 func (a TimeFrameEvents) Filter(event models.Event) bool {
+	// if it is an all-day event, it should not be filtered here,
+	// the AllDayEvents filter should be used instead
+	if event.AllDay {
+		return true
+	}
 
 	// if start time is inside the timeframe
 	// example: event from 10-12, timeframe is 8-18

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -133,14 +133,30 @@ func IsSameEvent(a, b Event) bool {
 		return false
 	}
 
-	if !a.StartTime.Equal(b.StartTime) {
-		log.Debugf("StartTime of Source Event %s changed, sourceTime: %s, sinkTime: %s ", a.Title, a.StartTime, b.StartTime)
+	if a.AllDay != b.AllDay {
+		log.Debugf("AllDay of Source Event %s at %s changed", a.Title, a.StartTime)
 		return false
 	}
 
-	if !a.EndTime.Equal(b.EndTime) {
-		log.Debugf("EndTime of Source Event %s changed, sourceTime: %s, sinkTime: %s ", a.Title, a.StartTime, b.StartTime)
-		return false
+	if a.AllDay && b.AllDay {
+		// only compare dates
+		if a.StartTime.Year() != b.StartTime.Year() || a.StartTime.YearDay() != b.StartTime.YearDay() {
+			log.Debugf("StartTime of all-day event %s changed, sourceTime: %s, sinkTime: %s", a.Title, a.StartTime.Format(time.DateOnly), b.StartTime.Format(time.DateOnly))
+			return false
+		}
+		if a.EndTime.Year() != b.EndTime.Year() || a.EndTime.YearDay() != b.EndTime.YearDay() {
+			log.Debugf("EndTime of all-day event %s changed, sourceTime: %s, sinkTime: %s", a.Title, a.EndTime.Format(time.DateOnly), b.EndTime.Format(time.DateOnly))
+			return false
+		}
+	} else {
+		if !a.StartTime.Equal(b.StartTime) {
+			log.Debugf("StartTime of Source Event %s changed, sourceTime: %s, sinkTime: %s ", a.Title, a.StartTime, b.StartTime)
+			return false
+		}
+		if !a.EndTime.Equal(b.EndTime) {
+			log.Debugf("EndTime of Source Event %s changed, sourceTime: %s, sinkTime: %s ", a.Title, a.StartTime, b.StartTime)
+			return false
+		}
 	}
 
 	if a.AllDay != b.AllDay {


### PR DESCRIPTION
This PR introduces some fixes for all-day events:
- the TimeFrame filter should not filter all-day events because if it does, there is no way to filter for business hours but keep the all-day events.
- for all-day events, only the dates should be compared, not the time. The reason for this change is that all-day events in zep start and end at 00:00 local time zone, whereas all-day events in google start and end at 00:00 UTC. Therefore, the event is always shown as "changed".