### PR TITLE
dependabot: group minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This change should let dependabot create a single pull request for all minor and patch releases, reducing the workload for maintainers. If you want, I can also look into the automerge behavior for minor and patch releases.