### PR TITLE
fix(Google): force eventReminder overrides and their fields to always be sent

### DIFF
--- a/internal/adapter/google/client.go
+++ b/internal/adapter/google/client.go
@@ -100,13 +100,15 @@ func (g *GCalClient) CreateEvent(ctx context.Context, event models.Event) error 
 	}
 
 	var calendarReminders calendar.EventReminders
+	calendarReminders.ForceSendFields = []string{"UseDefault", "Overrides"}
 	for _, reminder := range event.Reminders {
 		if reminder.Actions == models.ReminderActionDisplay {
-			calendarReminders.ForceSendFields = []string{"UseDefault"}
-			calendarReminders.Overrides = append(calendarReminders.Overrides, &calendar.EventReminder{
-				Method:  "popup",
-				Minutes: int64(event.StartTime.Sub(reminder.Trigger.PointInTime).Minutes()),
-			})
+			var calendarOverride = &calendar.EventReminder{
+				Method:          "popup",
+				Minutes:         int64(event.StartTime.Sub(reminder.Trigger.PointInTime).Minutes()),
+				ForceSendFields: []string{"Method", "Minutes"}, // Google API requires e.g `Minutes` to be send even if 0 - https://pkg.go.dev/google.golang.org/api/calendar/v3?utm_source=godoc#EventReminder
+			}
+			calendarReminders.Overrides = append(calendarReminders.Overrides, calendarOverride)
 		}
 	}
 


### PR DESCRIPTION
Google Calendar API requires certain fields to be sent with a request, even though they might not be marshalled if they are set to their default, null or 0 - see [1]

This is the case e.g if an EventReminder has "0" minutes set which causes Google to reject with: `googleapi: Error 400: Missing override reminder minutes., required`

[1] https://pkg.go.dev/google.golang.org/api/calendar/v3?utm_source=godoc#EventReminder