### PR TITLE
fix: improve placeholder email when KeepAttendees is used

### DIFF
--- a/internal/transformation/keepAttendees.go
+++ b/internal/transformation/keepAttendees.go
@@ -3,6 +3,7 @@ package transformation
 import (
 	"fmt"
 	"net/mail"
+	"strings"
 
 	"github.com/inovex/CalendarSync/internal/models"
 )
@@ -28,16 +29,15 @@ func (t *KeepAttendees) Transform(source models.Event, sink models.Event) (model
 		}
 
 		var email = sourceAttendee.Email
-		// Hashing the email and creating the new email to use
-		emailHashedAndTransformed := fmt.Sprintf("%s@localhost", fmt.Sprint(models.Hash(email)))
+		emailTransformed := fmt.Sprintf("%s@localhost", fmt.Sprint(strings.ReplaceAll(email, "@", "_")))
 
-		if _, err := mail.ParseAddress(emailHashedAndTransformed); err != nil {
-			return models.Event{}, fmt.Errorf("no valid email address %s: %w", emailHashedAndTransformed, err)
+		if _, err := mail.ParseAddress(emailTransformed); err != nil {
+			return models.Event{}, fmt.Errorf("no valid email address %s: %w", emailTransformed, err)
 		}
 
 		sinkAttendees = append(sinkAttendees, models.Attendee{
 			DisplayName: displayName,
-			Email:       emailHashedAndTransformed,
+			Email:       emailTransformed,
 		})
 	}
 	sink.Attendees = sinkAttendees

--- a/internal/transformation/keepAttendees_test.go
+++ b/internal/transformation/keepAttendees_test.go
@@ -1,7 +1,6 @@
 package transformation
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,11 +41,11 @@ func TestKeepAttendeesWithAnonymousEmail(t *testing.T) {
 		Attendees: []models.Attendee{
 			{
 				DisplayName: "Foo",
-				Email:       fmt.Sprintf("%s@localhost", fmt.Sprint(models.Hash("foo@example.com"))),
+				Email:       "foo_example.com@localhost",
 			},
 			{
 				DisplayName: "Bar",
-				Email:       fmt.Sprintf("%s@localhost", fmt.Sprint(models.Hash("bar@example.com"))),
+				Email:       "bar_example.com@localhost",
 			},
 		},
 	}
@@ -88,11 +87,11 @@ func TestKeepAttendeesWithEmailAsDisplayName(t *testing.T) {
 		Attendees: []models.Attendee{
 			{
 				DisplayName: "foo@example.com",
-				Email:       fmt.Sprintf("%s@localhost", fmt.Sprint(models.Hash("foo@example.com"))),
+				Email:       "foo_example.com@localhost",
 			},
 			{
 				DisplayName: "bar@example.com",
-				Email:       fmt.Sprintf("%s@localhost", fmt.Sprint(models.Hash("bar@example.com"))),
+				Email:       "bar_example.com@localhost",
 			},
 		},
 	}


### PR DESCRIPTION
With Google Calendar, DisplayName does not work correctly. Therefore this works as a workaround to better see the attendees.