### PR TITLE
fix: keep city/state/postcode when mapping an Outlook event location

### DIFF
--- a/internal/adapter/outlook_http/client.go
+++ b/internal/adapter/outlook_http/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -252,6 +253,27 @@ func (o OutlookClient) eventToOutlookEvent(e models.Event) (oe Event) {
 	return outlookEvent
 }
 
+// flattenLocation renders an Outlook location as the engine's single free-text
+// Location string. Graph keeps the friendly name in displayName and the
+// street/city/state/postcode only in the structured address, so address parts
+// not already present in displayName are appended to survive the string sink.
+func flattenLocation(l Location) string {
+	if l.Address == nil {
+		return l.Name
+	}
+	parts := make([]string, 0, 5)
+	if l.Name != "" {
+		parts = append(parts, l.Name)
+	}
+	for _, p := range []string{l.Address.Street, l.Address.City, l.Address.State, l.Address.PostalCode} {
+		if p == "" || strings.Contains(l.Name, p) {
+			continue
+		}
+		parts = append(parts, p)
+	}
+	return strings.Join(parts, ", ")
+}
+
 // outlookEventToEvent transforms an outlook event to our form of event representation
 // gets called when used as a sink and as a source
 func (o OutlookClient) outlookEventToEvent(oe Event, adapterSourceID string) (e models.Event, err error) {
@@ -295,7 +317,7 @@ func (o OutlookClient) outlookEventToEvent(oe Event, adapterSourceID string) (e 
 		ID:          oe.ID,
 		Title:       oe.Subject,
 		Description: oe.Body.Content,
-		Location:    oe.Location.Name,
+		Location:    flattenLocation(oe.Location),
 		StartTime:   startTime,
 		EndTime:     endTime,
 		Metadata:    ensureMetadata(oe, adapterSourceID),

--- a/internal/adapter/outlook_http/location_flatten_test.go
+++ b/internal/adapter/outlook_http/location_flatten_test.go
@@ -1,0 +1,27 @@
+package outlook_http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// flattenLocation must leave a plain display-name location untouched (nil
+// address) and must not duplicate a component already present in the name.
+func TestFlattenLocation(t *testing.T) {
+	assert.Equal(t, "Conference Room A",
+		flattenLocation(Location{Name: "Conference Room A"}),
+		"a nil address must return the display name unchanged")
+
+	// Venue name with a disjoint street address: street must survive.
+	got := flattenLocation(Location{Name: "Harry's Bar", Address: &PhysicalAddress{
+		Street: "123 Main St", City: "Springfield", State: "IL", PostalCode: "62704",
+	}})
+	assert.Equal(t, "Harry's Bar, 123 Main St, Springfield, IL, 62704", got)
+
+	// displayName already holds the street: it must not be repeated.
+	got = flattenLocation(Location{Name: "123 Main St", Address: &PhysicalAddress{
+		Street: "123 Main St", City: "Springfield", State: "IL", PostalCode: "62704",
+	}})
+	assert.Equal(t, "123 Main St, Springfield, IL, 62704", got)
+}

--- a/internal/adapter/outlook_http/location_repro_test.go
+++ b/internal/adapter/outlook_http/location_repro_test.go
@@ -1,0 +1,72 @@
+package outlook_http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubTransport returns a fixed status code and body for every request.
+type stubTransport struct {
+	status int
+	body   string
+}
+
+func (s stubTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: s.status,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// An Outlook event's city/state/postcode live only in the structured
+// location.address object, while displayName is often just the street or a
+// venue name. Mapping displayName alone dropped the address, so the synced
+// copy carried only the street and navigation resolved it to a same-named
+// street in the wrong city.
+//
+// Fixture is a real Graph payload: displayName is the bare street and
+// Medina/Minnesota exist only inside address.
+func TestListEvents_StructuredAddress_SurvivesMapping(t *testing.T) {
+	graphResponse := `{"value":[{
+		"id":"evt-arrowhead",
+		"iCalUId":"evt-arrowhead-uid",
+		"subject":"Meeting to discuss CRM",
+		"start":{"dateTime":"2026-05-20T15:00:00.0000000","timeZone":"UTC"},
+		"end":{"dateTime":"2026-05-20T16:00:00.0000000","timeZone":"UTC"},
+		"location":{
+			"displayName":"3640 Arrowhead Dr",
+			"address":{
+				"street":"3640 Arrowhead Dr",
+				"city":"Medina",
+				"state":"Minnesota",
+				"postalCode":"55340",
+				"countryOrRegion":"United States"
+			}
+		},
+		"extensions":[]
+	}]}`
+
+	client := &OutlookClient{
+		Client:     &http.Client{Transport: stubTransport{status: http.StatusOK, body: graphResponse}},
+		CalendarID: "test-calendar",
+	}
+
+	events, err := client.ListEvents(context.Background(), time.Now(), time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	loc := events[0].Location
+	assert.Contains(t, loc, "Medina", "city lost — navigation routes to the wrong city (got %q)", loc)
+	assert.Contains(t, loc, "Minnesota", "state lost (got %q)", loc)
+	// displayName ("3640 Arrowhead Dr") equals address.street here, so the
+	// flatten must not repeat it.
+	assert.Equal(t, 1, strings.Count(loc, "3640 Arrowhead Dr"), "street double-printed (got %q)", loc)
+}

--- a/internal/adapter/outlook_http/models.go
+++ b/internal/adapter/outlook_http/models.go
@@ -63,5 +63,14 @@ type EmailAddress struct {
 }
 
 type Location struct {
-	Name string `json:"displayName"`
+	Name    string           `json:"displayName"`
+	Address *PhysicalAddress `json:"address,omitempty"`
+}
+
+type PhysicalAddress struct {
+	Street          string `json:"street,omitempty"`
+	City            string `json:"city,omitempty"`
+	State           string `json:"state,omitempty"`
+	PostalCode      string `json:"postalCode,omitempty"`
+	CountryOrRegion string `json:"countryOrRegion,omitempty"`
 }


### PR DESCRIPTION
will resubmit.